### PR TITLE
add basic support for typed actors

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -36,6 +36,7 @@ libraryDependencies ++= Seq(
   "org.apache.pekko" %% "pekko-slf4j" % pekkoVersion,
   "com.typesafe" % "config" % "1.4.3",
   "org.aspectj" % "aspectjweaver" % aspectjweaverVersion,
+  "org.apache.pekko" %% "pekko-actor-typed" % pekkoVersion % Test,
   "org.apache.pekko" %% "pekko-testkit" % pekkoVersion % Test,
   "org.scalatest" %% "scalatest" % "3.2.19" % Test,
   "ch.qos.logback" % "logback-classic" % "1.3.15" % Test

--- a/src/main/scala/com/github/pjfanning/micrometer/pekko/ActorMetrics.scala
+++ b/src/main/scala/com/github/pjfanning/micrometer/pekko/ActorMetrics.scala
@@ -35,6 +35,9 @@ object ActorMetrics {
     }
   }
   def hasMetricsFor(e: Entity): Boolean = map.contains(e)
+
+  private[pekko] def getMap(): Map[Entity, ActorMetrics] = map.toMap
+  private[pekko] def clear(): Unit = map.clear()
 }
 
 class ActorMetrics(entity: Entity) {

--- a/src/test/resources/application.conf
+++ b/src/test/resources/application.conf
@@ -7,7 +7,7 @@ pekko {
 micrometer.pekko {
   metric.filters {
     pekko-actor {
-      includes = [ "**/user/tracked-**", "*/user/measuring-**", "*/user/stop-**" ]
+      includes = [ "**/user/tracked-**", "*/user/measuring-**", "*/user/stop-**", "greet-service/**" ]
       excludes = [ "*/system/**", "*/user/IO-**", "**/user/tracked-explicitly-excluded-**" ]
     }
 

--- a/src/test/scala/com/github/pjfanning/micrometer/pekko/TypedActor.scala
+++ b/src/test/scala/com/github/pjfanning/micrometer/pekko/TypedActor.scala
@@ -1,0 +1,15 @@
+package com.github.pjfanning.micrometer.pekko
+
+import org.apache.pekko.actor.typed.{ActorRef, Behavior}
+import org.apache.pekko.actor.typed.scaladsl.Behaviors
+
+object TypedActor {
+  final case class Greet(whom: String, replyTo: ActorRef[Greeted])
+  final case class Greeted(whom: String, from: ActorRef[Greet])
+
+  def apply(): Behavior[Greet] = Behaviors.receive { (context, message) =>
+    context.log.info("Hello {}!", message.whom)
+    message.replyTo ! Greeted(message.whom, context.self)
+    Behaviors.same
+  }
+}

--- a/src/test/scala/com/github/pjfanning/micrometer/pekko/TypedActorMetricsSpec.scala
+++ b/src/test/scala/com/github/pjfanning/micrometer/pekko/TypedActorMetricsSpec.scala
@@ -1,19 +1,3 @@
-/*
- * =========================================================================================
- * Copyright © 2017,2018 Workday, Inc.
- * Copyright © 2013-2017 the kamon project <http://kamon.io/>
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
- * except in compliance with the License. You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the
- * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
- * either express or implied. See the License for the specific language governing permissions
- * and limitations under the License.
- * =========================================================================================
- */
 package com.github.pjfanning.micrometer.pekko
 
 import com.github.pjfanning.micrometer.pekko.TypedActor.{Greet, Greeted}

--- a/src/test/scala/com/github/pjfanning/micrometer/pekko/TypedActorMetricsSpec.scala
+++ b/src/test/scala/com/github/pjfanning/micrometer/pekko/TypedActorMetricsSpec.scala
@@ -1,0 +1,52 @@
+/*
+ * =========================================================================================
+ * Copyright © 2017,2018 Workday, Inc.
+ * Copyright © 2013-2017 the kamon project <http://kamon.io/>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ * =========================================================================================
+ */
+package com.github.pjfanning.micrometer.pekko
+
+import com.github.pjfanning.micrometer.pekko.TypedActor.{Greet, Greeted}
+import org.apache.pekko.actor.typed.ActorSystem
+import org.apache.pekko.actor.typed.scaladsl.AskPattern.Askable
+import org.apache.pekko.util.Timeout
+
+import scala.concurrent.duration.DurationInt
+import scala.concurrent.Await
+
+class TypedActorMetricsSpec extends BaseSpec {
+
+  private val system: ActorSystem[Greet] = ActorSystem(TypedActor(), "greet-service")
+
+  override def afterAll(): Unit = {
+    super.afterAll()
+    system.terminate()
+    ActorMetrics.clear()
+  }
+
+  "the typed actor metrics" should {
+    "respect the configured include and exclude filters" in {
+      sendMessage("world")
+      val map = ActorMetrics.getMap()
+      map should not be empty
+      val entity = Entity("greet-service/user", MetricsConfig.Actor)
+      val metrics = map(entity)
+      metrics.messages.count() shouldEqual 2.0
+    }
+  }
+
+  def sendMessage(name: String): Unit = {
+    val fut = system.ask[Greeted](Greet(name, _))(Timeout(10.seconds), system.scheduler)
+    Await.result(fut, 10.seconds)
+  }
+}

--- a/src/test/scala/org/apache/pekko/actor/typed/instrumentation/ClassSpec.scala
+++ b/src/test/scala/org/apache/pekko/actor/typed/instrumentation/ClassSpec.scala
@@ -1,0 +1,14 @@
+package org.apache.pekko.actor.typed.instrumentation
+
+import com.github.pjfanning.micrometer.pekko.BaseSpec
+import org.apache.pekko.actor.typed.internal.adapter.ActorAdapter
+import org.apache.pekko.monitor.instrumentation.CellInfo
+
+class ClassSpec extends BaseSpec {
+
+  "Classloading" should {
+    "match TypedActorAdapterClassName" in {
+      Class.forName(CellInfo.TypedActorAdapterClassName) shouldEqual classOf[ActorAdapter[_]]
+    }
+  }
+}


### PR DESCRIPTION
Pekko typed actors (as opposed to classic actors) are implemented using classic actor code under the hood.
The code in micrometer-pekko mistakes these actors are supervisor actors and ignores them.
This PR tries to allow the "user" actor for the typed actor system to be tracked.